### PR TITLE
Fixes in cscodec

### DIFF
--- a/cscodec/Tests.cscodec.h264/Tests.cscodec.h264.csproj
+++ b/cscodec/Tests.cscodec.h264/Tests.cscodec.h264.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Tests.cscodec.h264</RootNamespace>
     <AssemblyName>Tests.cscodec.h264</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/cscodec/cscodec.h264/decoder/CAVLCContext.cs
+++ b/cscodec/cscodec.h264/decoder/CAVLCContext.cs
@@ -663,7 +663,7 @@ namespace cscodec.h264.decoder
 					// Fix: for difference between JAVA and C, we need to convert signed to unsigned when we compare
 					//      signed and unsigned number because, in C, such comparing will be done in common part.
 					//      In which, common part in C in unsigned, while java is signed. -= Nok =-
-					suffix_length += (((0xffffffffL & (suffix_limit[suffix_length] + level_code)) > (2 * suffix_limit[suffix_length])) ? 1 : 0);
+					suffix_length += (((0xffffffffL & (suffix_limit[suffix_length] + level_code)) > (2L * suffix_limit[suffix_length])) ? 1 : 0);
 				}
 
 				// DebugTool.printDebugString("   - suffix_length(2) = "+suffix_length+"\n");

--- a/cscodec/cscodec.h264/decoder/H264Context.cs
+++ b/cscodec/cscodec.h264/decoder/H264Context.cs
@@ -2515,7 +2515,7 @@ namespace cscodec.h264.decoder
 				{
 					for (int i = 0; i < 8; i++)
 					{
-						top_border_base[top_border_offset + 0 + i] = src_y_base[src_y_offset + 1 + i];
+                        src_y_base[src_y_offset + 1 + i] = (byte)top_border_base[top_border_offset + 0 + i];
 					} // for i	        	
 				} // if
 
@@ -2537,22 +2537,21 @@ namespace cscodec.h264.decoder
 					} // for i	        	
 					//XCHG(this.top_borders[top_idx][s.mb_x+1], src_y +17, 1);
 				}
-			}
 
 			//if(simple !=0|| 0==MpegEncContext.CONFIG_GRAY || 0==(s.flags&MpegEncContext.CODEC_FLAG_GRAY)){
-			if (deblock_top != 0)
+			    if (simple != 0)
 			{
 				if (deblock_left != 0)
 				{
 					for (int i = 0; i < 8; i++)
 					{
 						tmp = top_border_m1_base[top_border_m1_offset + 16 + i];
-						top_border_m1_base[top_border_m1_offset + 16 + i] = (sbyte)src_cb_base[src_cb_offset + 1 + i];
-						src_cb_base[src_cb_offset + 1 + i] = (byte)tmp;
+						    top_border_m1_base[top_border_m1_offset + 16 + i] = (sbyte)src_cb_base[src_cb_offset - 7 + i];
+						    src_cb_base[src_cb_offset - 7 + i] = (byte)tmp;
 
 						tmp = top_border_m1_base[top_border_m1_offset + 24 + i];
-						top_border_m1_base[top_border_m1_offset + 24 + i] = (sbyte)src_cr_base[src_cr_offset + 1 + i];
-						src_cr_base[src_cr_offset + 1 + i] = (byte)tmp;
+						    top_border_m1_base[top_border_m1_offset + 24 + i] = (sbyte)src_cr_base[src_cr_offset - 7 + i];
+						    src_cr_base[src_cr_offset - 7 + i] = (byte)tmp;
 					} // for i		        	
 				}
 
@@ -2567,7 +2566,7 @@ namespace cscodec.h264.decoder
 					src_cr_base[src_cr_offset + 1 + i] = (byte)tmp;
 				} // for i
 			}
-			//}
+			}
 		}
 
 		public /*av_always_inline*/ void hl_decode_mb_internal(int simple)
@@ -9726,7 +9725,7 @@ ref_cache[list][scan8[4 * i] + 8] = ref_cache[list][scan8[4 * i] + 9] = @ref[lis
 				for (i = 0; i < cnt; i++)
 				{
 					//nalsize = AV_RB16(p) + 2;
-					nalsize = ((p_base[p_offset] & 0x0ff) | ((p_base[p_offset + 1] & 0x0ff) << 8)) + 2;
+					nalsize = ((p_base[p_offset + 1] & 0x0ff) | ((p_base[p_offset] & 0x0ff) << 8)) + 2;
 					if (decode_nal_units(p_base, p_offset, nalsize) < 0)
 					{
 						//av_log(avctx, AV_LOG_ERROR, "Decoding sps %d from avcC failed\n", i);
@@ -9739,7 +9738,7 @@ ref_cache[list][scan8[4 * i] + 8] = ref_cache[list][scan8[4 * i] + 9] = @ref[lis
 				for (i = 0; i < cnt; i++)
 				{
 					//nalsize = AV_RB16(p) + 2;
-					nalsize = ((p_base[p_offset] & 0x0ff) | ((p_base[p_offset + 1] & 0x0ff) << 8)) + 2;
+					nalsize = ((p_base[p_offset + 1] & 0x0ff) | ((p_base[p_offset] & 0x0ff) << 8)) + 2;
 					if (decode_nal_units(p_base, p_offset, nalsize) != nalsize)
 					{
 						//av_log(avctx, AV_LOG_ERROR, "Decoding pps %d from avcC failed\n", i);

--- a/cscodec/cscodec.h264/decoder/PictureParameterSet.cs
+++ b/cscodec/cscodec.h264/decoder/PictureParameterSet.cs
@@ -27,6 +27,10 @@ namespace cscodec.h264.decoder
 
 		public void copyTo(PictureParameterSet pps)
 		{
+            if (this == pps)
+            {
+                return;
+            }
 			pps.sps_id = sps_id;
 			pps.cabac = cabac;                  ///< entropy_coding_mode_flag
 			pps.pic_order_present = pic_order_present;      ///< pic_order_present_flag

--- a/cscodec/cscodec.h264/decoder/SequenceParameterSet.cs
+++ b/cscodec/cscodec.h264/decoder/SequenceParameterSet.cs
@@ -85,6 +85,10 @@ namespace cscodec.h264.decoder
 
 		public void copyTo(SequenceParameterSet sps)
 		{
+            if (this == sps)
+            {
+                return;
+            }
 			sps.profile_idc = profile_idc;
 			sps.level_idc = level_idc;
 			sps.chroma_format_idc = chroma_format_idc;

--- a/cscodec/cscodec.h264/player/FrameDecoder.cs
+++ b/cscodec/cscodec.h264/player/FrameDecoder.cs
@@ -2,12 +2,7 @@
 using cscodec.h264.decoder;
 using cscodec.util;
 using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
-using System.Linq;
-using System.Text;
-using cscodec;
 
 namespace cscodec.h264.player
 {

--- a/cscodec/cscodec.samples/H264Player.cs
+++ b/cscodec/cscodec.samples/H264Player.cs
@@ -1,5 +1,3 @@
-using cscodec.h264.decoder;
-using cscodec.h264.player;
 using System;
 using System.Drawing;
 using System.IO;
@@ -22,66 +20,58 @@ namespace cscodec.h264.player
 		{
 			if (args.Length < 1)
 			{
-				var OpenFileDialog = new OpenFileDialog();
-				OpenFileDialog.CheckFileExists = true;
-				OpenFileDialog.Filter = "h264 files|*.h264;*.264|All Files|*.*";
-				if (OpenFileDialog.ShowDialog() == DialogResult.OK)
-				{
-					args = new string[] { OpenFileDialog.FileName };
-				}
-				else
-				{
-					Console.WriteLine("Usage: H264Player <.h264 raw file>\n");
-					return;
-				}
+			    var OpenFileDialog = new OpenFileDialog
+			    {
+			        CheckFileExists = true,
+			        Filter = "h264 files|*.h264;*.264|All Files|*.*"
+			    };
+			    if (OpenFileDialog.ShowDialog() != DialogResult.OK)
+			    {
+			        Console.WriteLine("Usage: H264Player <.h264 raw file>\n");
+			        return;
+			    }
+			    args = new[] {OpenFileDialog.FileName};
 			}
 
-			// TODO Auto-generated method stub
+		    // TODO Auto-generated method stub
 			if (args.Length < 1)
 			{
 				Console.WriteLine("Usage: H264Player <.h264 raw file>\n");
 				return;
 			}
-			else
-			{
-				var H264Player = new H264Player();
+		    var H264Player = new H264Player
+		    {
+		        frame = new Form
+		        {
+		            Text = "cscodec.h264 Player",
+		            FormBorderStyle = FormBorderStyle.FixedDialog,
+		            MinimizeBox = false,
+		            StartPosition = FormStartPosition.CenterScreen
+		        }
+		    };
 
-				H264Player.frame = new Form()
-				{
-					Text = "cscodec.h264 Player",
-					FormBorderStyle = FormBorderStyle.FixedDialog,
-					MinimizeBox = false,
-					StartPosition = FormStartPosition.CenterScreen,
-				};
-				//displayPanel = new PlayerFrame();
+		    //displayPanel = new PlayerFrame();
 
-				//frame.getContentPane().add(displayPanel, BorderLayout.CENTER);
+		    //frame.getContentPane().add(displayPanel, BorderLayout.CENTER);
 
-				// Finish setting up the frame, and show it.
-				H264Player.frame.FormClosing += (s, e) =>
-				{
-					Environment.Exit(0);
-				};
+		    // Finish setting up the frame, and show it.
+		    H264Player.frame.FormClosing += (s, e) =>
+		    {
+		        Environment.Exit(0);
+		    };
 
-				H264Player.frame.HandleCreated += (s, e) =>
-				{
-					new Thread(() =>
-					{
-						H264Player.run(args[0]);
-					}).Start();
-				};
+		    H264Player.frame.HandleCreated += (s, e) =>
+		    {
+		        new Thread(() =>
+		        {
+		            H264Player.run(args[0]);
+		        }).Start();
+		    };
 
-				Application.Run(H264Player.frame);
-
-			} // if
+		    Application.Run(H264Player.frame);
 		}
 
-		public H264Player()
-		{
-
-		}
-
-		public void run(string fileName)
+	    public void run(string fileName)
 		{
 			Console.WriteLine("Playing " + fileName);
 			playFile(fileName);
@@ -109,15 +99,15 @@ namespace cscodec.h264.player
 						var Width = picture.imageWidthWOEdge;
 						var Height = picture.imageHeightWOEdge;
 
-						if (this.frame.ClientSize.Width < Width || this.frame.ClientSize.Height < Height)
+						if (frame.ClientSize.Width < Width || frame.ClientSize.Height < Height)
 						{
-							this.frame.Invoke((Action)(() =>
+							frame.Invoke((Action)(() =>
 							{
-								this.frame.ClientSize = new Size(Width, Height);
-								CenterForm(this.frame);
+								frame.ClientSize = new Size(Width, Height);
+								CenterForm(frame);
 							}));
 						}
-						this.frame.CreateGraphics().DrawImage(FrameUtils.imageFromFrameWithoutEdges(picture, Width, Height), Point.Empty);
+						frame.CreateGraphics().DrawImage(picture.ToImageWOEdges(Width, Height), Point.Empty);
 					}
 				}
 				catch (EndOfStreamException)

--- a/cscodec/cscodec.samples/cscodec.samples.csproj
+++ b/cscodec/cscodec.samples/cscodec.samples.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>cscodec.samples</RootNamespace>
     <AssemblyName>cscodec.samples</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/cscodec/cscodec/FrameCrc.cs
+++ b/cscodec/cscodec/FrameCrc.cs
@@ -1,8 +1,6 @@
 ﻿using cscodec.av;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace cscodec
 {

--- a/cscodec/cscodec/MathUtils.cs
+++ b/cscodec/cscodec/MathUtils.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace cscodec
+﻿namespace cscodec
 {
-	public class MathUtils
+	public static class MathUtils
 	{
 		static public int Clamp(int Value, int Min, int Max)
 		{

--- a/cscodec/cscodec/av/AVPacket.cs
+++ b/cscodec/cscodec/av/AVPacket.cs
@@ -54,13 +54,13 @@ namespace cscodec.av
 
 		public void av_init_packet()
 		{
-			this.pts = Constants.AV_NOPTS_VALUE;
-			this.dts = Constants.AV_NOPTS_VALUE;
-			this.pos = -1;
-			this.duration = 0;
-			this.convergence_duration = 0;
-			this.flags = 0;
-			this.stream_index = 0;
+			pts = Constants.AV_NOPTS_VALUE;
+			dts = Constants.AV_NOPTS_VALUE;
+			pos = -1;
+			duration = 0;
+			convergence_duration = 0;
+			flags = 0;
+			stream_index = 0;
 			//this.destruct= null;
 		}
 	}

--- a/cscodec/cscodec/av/Constants.cs
+++ b/cscodec/cscodec/av/Constants.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace cscodec.av
+﻿namespace cscodec.av
 {
 	public class Constants
 	{

--- a/cscodec/cscodec/av/ImageUtils.cs
+++ b/cscodec/cscodec/av/ImageUtils.cs
@@ -1,4 +1,3 @@
-using cscodec.av;
 using cscodec.util;
 using System;
 namespace cscodec.av

--- a/cscodec/cscodec/av/PixFmtYUV420P.cs
+++ b/cscodec/cscodec/av/PixFmtYUV420P.cs
@@ -1,5 +1,3 @@
-using cscodec.av;
-
 namespace cscodec.av
 {
 	public class PixFmtYUV420P : AVPixFmtDescriptor

--- a/cscodec/cscodec/util/Arrays.cs
+++ b/cscodec/cscodec/util/Arrays.cs
@@ -1,8 +1,8 @@
-using System;
+using System.Linq;
 
 namespace cscodec.util
 {
-	public class Arrays
+	public static class Arrays
 	{
 		public static T[][] ConvertDimensional<T>(T[,] In)
 		{
@@ -58,11 +58,9 @@ namespace cscodec.util
 			return Ret;
 		}
 
-		public static bool Equals<T>(T[] Array1, T[] Array2)
+		public static bool Equals(int[] Array1, int[] Array2)
 		{
-			if (Array1.Length != Array2.Length) return false;
-			for (int n = 0; n < Array1.Length; n++) if (Array1 != Array2) return false;
-			return true;
+		    return (Array1.Length == Array2.Length) && Array1.Zip(Array2, (x, y) => x == y).All(x => x);
 		}
 
 		public static void Fill<T>(T[] Array, int IndexStart, int IndexEnd, T Value)


### PR DESCRIPTION
I was trying using cscodec to decode a h264 live stream from a samsung ip camera, and discovered that images were affected by color bleeding.
I tried porting all the latest fixes from h264j project (up to r11), and most of the problems are now solved. 
